### PR TITLE
157 EI does not have interrupt point

### DIFF
--- a/CPU.Business/CPU.cs
+++ b/CPU.Business/CPU.cs
@@ -552,7 +552,6 @@ namespace CPU.Business
         // Return the status only for Zero and Sign
         private void ComputeLogicFlags()
         {
-            Registers[REGISTERS.FLAGS] = 0;
             if (RBUS == 0)
             {
                 Registers[REGISTERS.FLAGS] |= (ushort)(1 << zeroShift);

--- a/CPU.Business/ControlUnit.cs
+++ b/CPU.Business/ControlUnit.cs
@@ -218,8 +218,8 @@ namespace CPU.Business
                         bool aluBIT24 = Convert.ToBoolean(mirALUBits & 1);
                         bool aluBIT25 = Convert.ToBoolean(mirALUBits & (1 << 1));
                         if (!aluBIT24 & !aluBIT25)
-                            state = 2;
-                        else state = 0;
+                            state = 0;
+                        else state = 2;
                         return DecodeAndSendCommand();
                     case 2:
                         state = 3;

--- a/Configs/MPM.json
+++ b/Configs/MPM.json
@@ -301,8 +301,8 @@
     ],
     "EI":
     [
-        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(1)BVI",         "JUMPI",            "INDEX7",  "T",  "IFCH"         ],
-        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "STEP",             "INDEX0",  "T",  "0"            ]
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "A(1)BVI",         "STEP",            "INDEX7",  "T",  "0"         ],
+        ["NONE",      "NONE",          "NONE",  "NONE",        "NONE",    "NONE",            "JUMPI",             "INDEX7",  "T",  "IFCH"            ]
     ],
     "DI":
     [


### PR DESCRIPTION
# What is the issue?
Firstly, EI instruction did not have interrupt point, meaning that despite activating interrupts and having active ones, the code would not jump. Secondly, arithmetic and logical instructions would erase the interrupt validation signal.

# What has been done?
Removed code that resets `FLAG` register for arithmetic and logic operations and updated `MPM` in order for EI to have a functioning interrupt point.
## Note
While looking over code, `ControlUnit.cs` has been updated based on the following diagram
<img width="581" height="826" alt="seq_io" src="https://github.com/user-attachments/assets/1721c914-7b55-4816-86d4-3c08dea73104" />


# How to review?
Manual run and code review.