### PR TITLE
176 UI make run button work only after having assembled the code

### DIFF
--- a/Ui/Interfaces/ViewModel/IActionsBarViewModel.cs
+++ b/Ui/Interfaces/ViewModel/IActionsBarViewModel.cs
@@ -43,6 +43,7 @@ namespace Ui.Interfaces.ViewModel
         bool NotDebugging { get; set; }
         bool CanDebug { get; set; }
         bool CanAssemble { get; set; }
+        bool CanRun { get; set; }
 
         event PropertyChangedEventHandler? PropertyChanged;
         event PropertyChangingEventHandler? PropertyChanging;

--- a/Ui/ViewModels/Generics/ActionsBarViewModel.cs
+++ b/Ui/ViewModels/Generics/ActionsBarViewModel.cs
@@ -59,28 +59,32 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
     {
         StepLevel = level;
     }
-
     [RelayCommand]
-    private void RunCode()
+    private async Task RunCode()
     {
         ushort haltCode = 0xE300;
         ushort irValue = _cpuService.GetIR();
+
         while (irValue != haltCode)
         {
-            _cpuService.StepMicroinstruction();
+
+            _cpuService.StepInstruction();
             irValue = _cpuService.GetIR();
+
+            await Task.Yield();
+            await Task.Delay(1);
         }
-        _cpuService.StepMicroinstruction();
-        _cpuService.StepMicroinstruction();
-        _cpuService.StepMicroinstruction();
-        _cpuService.StepMicroinstruction();
-        _cpuService.StepMicroinstruction();
+
+        for (int i = 0; i < 5; i++)
+        {
+            _cpuService.StepMicroinstruction();
+        }
+
         CanAssemble = true;
         IsDebugging = true;
         NotDebugging = false;
         CanDebug = false;
     }
-
     [RelayCommand]
     private async Task RunAssembleSourceCodeService()
     {

--- a/Ui/ViewModels/Generics/ActionsBarViewModel.cs
+++ b/Ui/ViewModels/Generics/ActionsBarViewModel.cs
@@ -62,6 +62,8 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
     [RelayCommand]
     private async Task RunCode()
     {
+        if (_activeDocumentService.SelectedDocument == null) return;
+
         ushort haltCode = 0xE300;
         ushort irValue = _cpuService.GetIR();
 
@@ -80,7 +82,6 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
             _cpuService.StepMicroinstruction();
         }
 
-        CanAssemble = true;
         IsDebugging = true;
         NotDebugging = false;
         CanDebug = false;
@@ -160,7 +161,6 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
             IsDebugging = false;
             NotDebugging = true;
             CanDebug = true;
-            CanAssemble = true;
         }
     }
     [RelayCommand]

--- a/Ui/ViewModels/Generics/ActionsBarViewModel.cs
+++ b/Ui/ViewModels/Generics/ActionsBarViewModel.cs
@@ -31,6 +31,8 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
     [ObservableProperty]
     public partial bool CanAssemble{ get; set; }
     [ObservableProperty]
+    public partial bool CanRun { get; set; }
+    [ObservableProperty]
     public partial StepLevel StepLevel { get; set; }
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
@@ -88,14 +90,16 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
         {
             CanAssemble = true;
             CanDebug = false;
+            CanRun = false;
             return;
         }
 
         _cpuService.UpdateDebugSymbols(_activeDocumentService.SelectedDocument.Content, debugSymbols, USER_CODE_START_ADDR);
-        
+
         _toolVisibilityService.ToggleToolVisibility(_activeDocumentService.HexViewer);
         CanDebug = true;
         CanAssemble = false;
+        CanRun = true;
     }
 
     [RelayCommand]

--- a/Ui/Views/Windows/MainWindow.xaml
+++ b/Ui/Views/Windows/MainWindow.xaml
@@ -143,7 +143,7 @@
             <StackPanel Grid.Column="0" Orientation="Horizontal" DataContext="{Binding ActionsBar}">
                 <ui:Button
                     Command="{Binding RunCodeCommand}"
-                    IsEnabled="{Binding CanDebug}"
+                    IsEnabled="{Binding CanRun}"
                     VerticalAlignment="Top"
                     ToolTip="Run"
                     Height="30"

--- a/Ui/Views/Windows/MainWindow.xaml.cs
+++ b/Ui/Views/Windows/MainWindow.xaml.cs
@@ -194,6 +194,7 @@ public partial class MainWindow
         { 
             _actionsBarViewModel.CanAssemble = false; 
             _actionsBarViewModel.CanDebug = false;
+            _actionsBarViewModel.CanRun = false;
         }
     }
     private void SaveCurrentDocument(FileViewModel document)


### PR DESCRIPTION
# What is the issue?
`Run` button was slow and it was tied to `Debug`.

# What has been done?
Decoupled buttons and made `Run` asynchronous.