### PR TITLE
175 UI fix muliple source files open bug

### DIFF
--- a/Ui/Components/StyledAvalonEdit.cs
+++ b/Ui/Components/StyledAvalonEdit.cs
@@ -23,6 +23,11 @@ public class StyledAvalonEdit : TextEditor, IAppearanceControl
         typeof(StyledAvalonEdit),
         new InputGestureCollection { new KeyGesture(Key.S, ModifierKeys.Control) });
     
+    // Add constants for min/max font size
+    private const double MinFontSize = 8.0;
+    private const double MaxFontSize = 36.0;
+    private const double DefaultFontSize = 10.0;
+    
     public StyledAvalonEdit()
     {
         //theming
@@ -43,6 +48,9 @@ public class StyledAvalonEdit : TextEditor, IAppearanceControl
         
         // Add command bindings
         CommandBindings.Add(new CommandBinding(SaveCommand, ExecuteSaveCommand));
+        
+        // Add zoom support with mouse wheel
+        PreviewMouseWheel += OnPreviewMouseWheel;
     }
     
     private void ExecuteSaveCommand(object sender, ExecutedRoutedEventArgs e)
@@ -135,9 +143,44 @@ public class StyledAvalonEdit : TextEditor, IAppearanceControl
         // Refresh the TextArea to update the colors
         TextArea.TextView.Redraw();
     }
+    
+    // Handle zoom functionality using Ctrl+MouseWheel
+    private void OnPreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    {
+        if (Keyboard.Modifiers == ModifierKeys.Control)
+        {
+            double fontSize = FontSize;
+            
+            if (e.Delta > 0)
+            {
+                // Zoom in
+                fontSize = Math.Min(fontSize + 1, MaxFontSize);
+            }
+            else
+            {
+                // Zoom out
+                fontSize = Math.Max(fontSize - 1, MinFontSize);
+            }
+            
+            if (fontSize != FontSize)
+            {
+                FontSize = fontSize;
+                System.Diagnostics.Debug.WriteLine($"Font size changed to: {FontSize}pt");
+            }
+            
+            e.Handled = true; // Prevent scrolling
+        }
+    }
+    
+    // Add a method to reset zoom to default
+    public void ResetZoom()
+    {
+        FontSize = DefaultFontSize;
+    }
 
     ~StyledAvalonEdit()
     {
         ApplicationThemeManager.Changed -= OnThemeChanged;
+        PreviewMouseWheel -= OnPreviewMouseWheel;
     }
 }

--- a/Ui/Services/CpuService.cs
+++ b/Ui/Services/CpuService.cs
@@ -209,6 +209,8 @@ public class CpuService : ICpuService
     {
         ushort lineNum = 0;
 
+        _activeDocumentService.SelectedDocument?.IsBeingDebugged = true;
+
         lineNum = GetLineAndEditorNumberByPc(_cpu.Registers[REGISTERS.PC]);
 
         _activeDocumentService.SelectedDocument?.HighlightLine(lineNum);
@@ -257,6 +259,7 @@ public class CpuService : ICpuService
         {
             doc.ResetHighlight();
         }
+        _activeDocumentService.SelectedDocument?.IsBeingDebugged = false;
         _diagram.ResetHighlight();
         _cpu.ResetProgram();
         _microprogramService.CurrentRow = -1;
@@ -306,10 +309,20 @@ public class CpuService : ICpuService
     {
         if (_activeDocumentService.SelectedDocument == null) return;
 
+        foreach (var doc in _activeDocumentService.Documents)
+        {
+            if ((section.Name == "User_Code") && (doc.IsBeingDebugged == true))
+            {
+                _activeDocumentService.SelectedDocument = doc;
+                return;
+            }
+        }
+
         // If the document is already open, select it
         foreach (var doc in _activeDocumentService.Documents)
         {
-            if ((doc.SectionName == section.Name))
+
+            if (doc.SectionName == section.Name)
             {
                 _activeDocumentService.SelectedDocument = doc;
                 return;

--- a/Ui/ViewModels/Components/MenuBar/MenuBarViewModel.cs
+++ b/Ui/ViewModels/Components/MenuBar/MenuBarViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.Win32;
+using Ui.Components;
 using Ui.Interfaces.Services;
 using Ui.Interfaces.ViewModel;
 using Ui.Models;
@@ -83,7 +84,7 @@ namespace Ui.ViewModels.Components.MenuBar
             {
                 Title = "Untitled",
                 Content = defaultContent,
-                SectionName = "User_Code"
+                SectionName = "User_Code",
             };
             DocumentService.Documents.Add(doc);
             DocumentService.SelectedDocument ??= doc;

--- a/Ui/ViewModels/Generics/ActionsBarViewModel.cs
+++ b/Ui/ViewModels/Generics/ActionsBarViewModel.cs
@@ -66,7 +66,7 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
 
         ushort haltCode = 0xE300;
         ushort irValue = _cpuService.GetIR();
-
+        _activeDocumentService.SelectedDocument.IsBeingDebugged = true;
         while (irValue != haltCode)
         {
 
@@ -105,6 +105,7 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
         CanDebug = true;
         CanAssemble = false;
         CanRun = true;
+        _activeDocumentService.SelectedDocument.NeedsAssemble = false;
     }
 
     [RelayCommand]
@@ -143,7 +144,7 @@ public partial class ActionsBarViewModel : ObservableObject, IActionsBarViewMode
     [RelayCommand]
     private void StartDebug()
     {
-        if (_activeDocumentService.SelectedDocument != null)
+        if (_activeDocumentService.SelectedDocument != null && _activeDocumentService.SelectedDocument.SectionName == "User_Code")
         {
             _cpuService.StartDebugging();
             IsDebugging = true;

--- a/Ui/ViewModels/Generics/FileViewModel.cs
+++ b/Ui/ViewModels/Generics/FileViewModel.cs
@@ -10,6 +10,7 @@ public partial class FileViewModel : PaneViewModel
     Color _semiTransparentYellow;
     public bool IsModified = false;
     public string SectionName = "User_Code";
+    public bool IsBeingDebugged = false;
     private int? _pendingHighlightLine = null;
 
     [ObservableProperty]
@@ -56,6 +57,7 @@ public partial class FileViewModel : PaneViewModel
                     HighlightLine(lineToHighlight);
                 }
             }
+            OnPropertyChanged(nameof(EditorInstance));
         }
     }
     public async Task LoadFromFile(string path)

--- a/Ui/Views/Windows/MainWindow.xaml.cs
+++ b/Ui/Views/Windows/MainWindow.xaml.cs
@@ -174,15 +174,22 @@ public partial class MainWindow
         {
             vm.EditorInstance = editor;
 
-            _actionsBarViewModel.CanAssemble = false;
-            _actionsBarViewModel.CanDebug = true;
-
-            if (((vm.IsModified == false) || vm.NeedsAssemble) && _actionsBarViewModel.IsDebugging == false)
+            if (
+                    (vm.NeedsAssemble) &&
+                    (_actionsBarViewModel.IsDebugging == false)
+                )
             {
                 _actionsBarViewModel.CanDebug = false;
                 _actionsBarViewModel.CanAssemble = true;
             }
-            
+
+            if (vm.SectionName != "User_Code")
+            {
+                _actionsBarViewModel.CanAssemble = false;
+                _actionsBarViewModel.CanDebug = false;
+                _actionsBarViewModel.CanRun = false;
+            }
+
             editor.SaveRequested += (s, args) => SaveCurrentDocument(vm);
 
             editor.Unloaded += OnEditorUnLoaded;


### PR DESCRIPTION
- added zoom in/ zoom out on text editor (not related to the ticket but it was needed)

# Previously how the bug was reproduced?

1. You opened two files (both containing user code)
2. Start debugging
3. The highlight was shown on the first file opened

This shall be fixed now and the highlight shall be placed on the active document when debugging starts