### PR TITLE
fix: Removed buggy loading of the least recently used layout

### DIFF
--- a/Ui/Interfaces/Services/IDockingService.cs
+++ b/Ui/Interfaces/Services/IDockingService.cs
@@ -12,5 +12,4 @@ public interface IDockingService
     List<string> GetAllLayoutNames();
     void DeleteLayout(string fileName);
     void SaveLastUsedLayout();
-    void LoadLastUsedLayout();
 }

--- a/Ui/Services/DockingService.cs
+++ b/Ui/Services/DockingService.cs
@@ -204,9 +204,4 @@ public class DockingService : IDockingService
         SaveLayout(LastUsedLayoutName);
     }
 
-    public void LoadLastUsedLayout()
-    {
-        if (GetAllLayoutNames().Contains(LastUsedLayoutName))
-            LoadLayout(LastUsedLayoutName);
-    }
 }

--- a/Ui/Services/DummyDockingService.cs
+++ b/Ui/Services/DummyDockingService.cs
@@ -40,9 +40,4 @@ public class DummyDockingService : IDockingService
     {
         throw new NotImplementedException();
     }
-
-    public void LoadLastUsedLayout()
-    {
-        throw new NotImplementedException();
-    }
 }

--- a/Ui/ViewModels/Components/MenuBar/MenuBarViewModel.cs
+++ b/Ui/ViewModels/Components/MenuBar/MenuBarViewModel.cs
@@ -37,7 +37,6 @@ namespace Ui.ViewModels.Components.MenuBar
             _dockingService = dockingService;
             _toolVisibilityService.SetDockingService(dockingService);
             LayoutControl.SetDockingService(dockingService);
-            _dockingService.LoadLastUsedLayout();
             files = DocumentService.Documents;
         }
 

--- a/Ui/Views/Windows/MainWindow.xaml.cs
+++ b/Ui/Views/Windows/MainWindow.xaml.cs
@@ -113,7 +113,6 @@ public partial class MainWindow
         
         // Reset the layout to initialize it properly with the new titles
         _docking.SaveLastUsedLayout();
-        _docking.LoadLastUsedLayout();
     }
     private void DockManager_AnchorableClosing(object? sender, AnchorableClosingEventArgs e)
     {


### PR DESCRIPTION
# What is the issue?
When making a window from Tools panel floating and then reopening the app, it would just crash.
# What has been done?
Removed the buggy load.
<img width="936" height="725" alt="image" src="https://github.com/user-attachments/assets/6ca2e8e4-46d9-4492-ab8d-2cad25dcf89a" />
